### PR TITLE
Add ability to execute commands in zones through zlogin

### DIFF
--- a/zone/Cargo.toml
+++ b/zone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Sean Klein <sean@oxide.computer>"]
 edition = "2018"
 repository = "https://github.com/oxidecomputer/zone"

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -5,6 +5,7 @@
 //! - Entrypoint for `zonecfg`: [Config].
 //! - Entrypoint for `zoneadm`: [Adm].
 //! - Entrypoint for `zonename`: [current].
+//! - Entrypoint for `zlogin`: [Zlogin].
 
 use itertools::Itertools;
 use std::collections::BTreeSet;
@@ -19,6 +20,7 @@ const PFEXEC: &str = "/bin/pfexec";
 const ZONENAME: &str = "/usr/bin/zonename";
 const ZONEADM: &str = "/usr/sbin/zoneadm";
 const ZONECFG: &str = "/usr/sbin/zonecfg";
+const ZLOGIN: &str = "/usr/sbin/zlogin";
 
 /// The error type for parsing a bad status code while reading stdout.
 #[derive(Error, Debug)]
@@ -867,6 +869,34 @@ impl Adm {
     }
 }
 
+/// Entry point for `zlogin` commands.
+pub struct Zlogin {
+    /// Name of the zone.
+    name: String,
+}
+
+impl Zlogin {
+    /// Instantiate a new zlogin command.
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Zlogin {
+            name: name.as_ref().into(),
+        }
+    }
+
+    /// Executes a command in the zone and returns the result.
+    pub fn exec(&self, cmd: impl AsRef<OsStr>) -> Result<String, ZoneError> {
+        Ok(std::process::Command::new(PFEXEC)
+            .env_clear()
+            .arg(ZLOGIN)
+            .arg("-Q")
+            .arg(&self.name)
+            .arg(cmd)
+            .output()
+            .map_err(ZoneError::Command)?
+            .read_stdout()?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1038,6 +1068,7 @@ mod tests {
         });
 
         cfg.run().unwrap();
+        cfg.delete(true).run().unwrap();
     }
 
     #[test]
@@ -1079,4 +1110,5 @@ mod tests {
             .find(|z| z.name() == name)
             .is_none());
     }
+
 }

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -1006,7 +1006,8 @@ mod tests {
         let mut cfg = Config::create("myzone", true, CreationOptions::Default);
         cfg.get_global()
             .set_path("/export/home/myzone")
-            .set_autoboot(true);
+            .set_autoboot(true)
+            .set_ip_type(IpType::Shared); // See: https://www.illumos.org/issues/14033
         cfg.add_fs(&Fs {
             ty: "lofs".to_string(),
             dir: "/usr/local".to_string(),

--- a/zone/tests/zlogin_test.rs
+++ b/zone/tests/zlogin_test.rs
@@ -1,0 +1,97 @@
+// Copyright 2021 Oxide Computer Company
+
+use std::path::Path;
+use zone::{Adm, Config, CreationOptions, Zlogin};
+
+const PFEXEC: &str = "/bin/pfexec";
+
+// This test is marked with ignore because it involves booting a newly created
+// zone which can take over a minute. This test assumes that the sparse brand is
+// installed, if not use `pkg install brand/sparse`.
+#[test]
+#[ignore]
+fn test_zlogin() {
+    // Setup zfs pool for zone.
+    zfs_zonetest_create();
+
+    let name = "zexec";
+    let path = Path::new("/zonetest/zexec");
+
+    // Create a zone.
+    let mut cfg = Config::create(name, true, CreationOptions::Default);
+    cfg.get_global()
+        .set_path(path)
+        .set_autoboot(true)
+        .set_brand("sparse");
+    cfg.run().unwrap();
+
+    // Install and boot zone, cleaning up on failure.
+    let mut adm = Adm::new(name);
+    adm.install(&[]).unwrap_or_else(|e| {
+        cfg.delete(true).run().unwrap();
+        zfs_zonetest_destroy();
+        panic!("{}", e);
+    });
+    adm.boot().unwrap_or_else(|e| {
+        adm.uninstall(true).unwrap();
+        cfg.delete(true).run().unwrap();
+        zfs_zonetest_destroy();
+        panic!("{}", e);
+    });
+
+    // Run the `hostname` command in the zone.
+    let zlogin = Zlogin::new(name);
+    let out = zlogin.exec("hostname").unwrap_or_else(|e| {
+        adm.halt().unwrap();
+        adm.uninstall(true).unwrap();
+        cfg.delete(true).run().unwrap();
+        zfs_zonetest_destroy();
+        panic!("{}", e);
+    });
+
+    // Run a command that should fail in the zone.
+    let bad_result = zlogin.exec("/usr/bin/notathing");
+
+    // Destroy the zone.
+    adm.halt().unwrap();
+    adm.uninstall(true).unwrap();
+    cfg.delete(true).run().unwrap();
+    zfs_zonetest_destroy();
+
+    // Running `hostname` within the zone should yield the name of the zone.
+    assert_eq!(out, "zexec");
+
+    // Running a bad command should yield an error.
+    match bad_result {
+        Ok(_) => panic!("expected error for bad command"),
+
+        // The exact content of the error will depend on the shell.
+        Err(e) => println!("got error: {:?}", e),
+    }
+}
+
+// Create a ZFS pool called zonetest.
+fn zfs_zonetest_create() {
+    std::process::Command::new(PFEXEC)
+        .env_clear()
+        .arg("zfs")
+        .arg("create")
+        .arg("-p")
+        .arg("-o")
+        .arg("mountpoint=/zonetest")
+        .arg("rpool/zonetest")
+        .output()
+        .unwrap();
+}
+
+// Destroy the zonetest zfs pool.
+fn zfs_zonetest_destroy() {
+    std::process::Command::new(PFEXEC)
+        .env_clear()
+        .arg("zfs")
+        .arg("destroy")
+        .arg("-rf")
+        .arg("rpool/zonetest")
+        .output()
+        .unwrap();
+}


### PR DESCRIPTION
This PR adds the ability to execute commands in zones through `zlogin`.

Testing for this capability is added as an integration style test with the [ignored](https://doc.rust-lang.org/book/ch11-02-running-tests.html#ignoring-some-tests-unless-specifically-requested) attribute. This is due to the fact that running the test requires booting a new zone, which can take over a minute in my experience.

One of the existing tests was not passing on my system due to [this issue](https://www.illumos.org/issues/14033) which I've added a workaround for.