### PR TITLE
Add sync, async features. Sync (old behavior) is default

### DIFF
--- a/zone/Cargo.toml
+++ b/zone/Cargo.toml
@@ -13,3 +13,9 @@ license = "MPL-2.0"
 thiserror = "1.0"
 itertools = "0.10"
 zone_cfg_derive = { version = "0.1.2", path = "../zone_cfg_derive" }
+tokio = { version = "1.2", features = [ "process" ], optional = true }
+
+[features]
+default = ["sync"]
+sync = []
+async = ["dep:tokio"]

--- a/zone/tests/zlogin_test.rs
+++ b/zone/tests/zlogin_test.rs
@@ -24,31 +24,31 @@ fn test_zlogin() {
         .set_path(path)
         .set_autoboot(true)
         .set_brand("sparse");
-    cfg.run()
+    cfg.run_blocking()
         .map_err(|e| format!("{}: try `pkg install brand/sparse`", e))
         .unwrap();
     let _unwind_config_create = Defer::new(|| {
-        cfg.delete(true).run().unwrap();
+        cfg.delete(true).run_blocking().unwrap();
     });
 
     // Install and boot zone.
     let mut adm = Adm::new(name);
-    adm.install(&[]).unwrap();
+    adm.install_blocking(&[]).unwrap();
     let _unwind_adm_install = Defer::new(|| {
-        Adm::new(name).uninstall(true).unwrap();
+        Adm::new(name).uninstall_blocking(true).unwrap();
     });
 
-    adm.boot().unwrap();
+    adm.boot_blocking().unwrap();
     let _unwind_adm_boot = Defer::new(|| {
-        Adm::new(name).halt().unwrap();
+        Adm::new(name).halt_blocking().unwrap();
     });
 
     // Run the `hostname` command in the zone.
     let zlogin = Zlogin::new(name);
-    let out = zlogin.exec("hostname").unwrap();
+    let out = zlogin.exec_blocking("hostname").unwrap();
 
     // Run a command that should fail in the zone.
-    let bad_result = zlogin.exec("/usr/bin/notathing");
+    let bad_result = zlogin.exec_blocking("/usr/bin/notathing");
 
     // Running `hostname` within the zone should yield the name of the zone.
     assert_eq!(out, "zexec");

--- a/zone_cfg_derive/src/lib.rs
+++ b/zone_cfg_derive/src/lib.rs
@@ -86,7 +86,7 @@ pub fn derive_resource(item: proc_macro::TokenStream) -> proc_macro::TokenStream
         This object represents the resource scope for a zone configuration, and
         automatically closes that scope when dropped.\n\n\
         To construct this object, refer to [Config::{}].",
-        input_name.to_string(),
+        input_name,
         if global_attrs.is_global_resource() {
             format!("get_{}", input_name.to_string().to_snake_case())
         } else {
@@ -168,8 +168,8 @@ fn selectors(input_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro
                     "Generated selector for the [{}] resource.\n\n\
                     Allows the selection of an existing resource for modification
                     with a matching value of [{}::{}].",
-                    input_name.to_string(),
-                    input_name.to_string(),
+                    input_name,
+                    input_name,
                     parsed.field_name(),
                 );
 
@@ -178,8 +178,8 @@ fn selectors(input_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro
                     "Generated removal function for the [{}] resource\n\n\
                     Allows the removal of all existing resources with a matching
                     value of [{}::{}].",
-                    input_name.to_string(),
-                    input_name.to_string(),
+                    input_name,
+                    input_name,
                     parsed.field_name(),
                 );
                 quote! {
@@ -260,7 +260,7 @@ fn constructor(
         let scope_get_msg = format!(
             "Acquire a reference to the global resource scope.
             This scope allows callers to safely set values within the [{}] object.",
-            input_name.to_string()
+            input_name
         );
         quote! {
             impl<'a> #scope_name<'a> {
@@ -285,13 +285,13 @@ fn constructor(
             "Creates a new scope from a [{}] object. This begins
             specification for the resource, and returns an object which
             represents the new scope.",
-            input_name.to_string()
+            input_name
         );
 
         let scope_removal = format_ident!("remove_all_{}", input_name_snake);
         let scope_removal_msg = format!(
             "Deletes resources associated with the [{}] object.",
-            input_name.to_string()
+            input_name
         );
 
         quote! {


### PR DESCRIPTION
- Adds the following feature flags:
  - `sync`: Enables synchronous calls via  `std::process::Command`. This is the default.
  - `async`: Enables asynchronous calls via `tokio::process::Command`
- Most functions are split into three different `pub` functions. Assume we had a function `foobar`, which previously made synchronous calls.
  1. `pub fn foobar`: We keep the old function, but mark it deprecated (the name collides with the async flavor)
  2. `pub fn foobar_blocking`: We add a new (preferable) name for that old function
  3. `pub async fn foobar`: We add a new async variant of that function