### PR TITLE
0.3.0: Provide access to zone commands instead of running them directly

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,12 @@
 
 = Zone Changelog
 
+== 0.3.0 (released 2023-08-09)
+
+=== Breaking Changes
+
+* https://github.com/oxidecomputer/zone/pull/22[#22] Removes deprecated methods, and makes the `sync` and `async` features usable together.
+
 == 0.2.0 (released 2022-11-14)
 
 === Breaking Changes

--- a/zone/Cargo.toml
+++ b/zone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Sean Klein <sean@oxide.computer>"]
 edition = "2018"
 repository = "https://github.com/oxidecomputer/zone"
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 [dependencies]
 thiserror = "1.0"
 itertools = "0.10"
-zone_cfg_derive = { version = "0.2.0", path = "../zone_cfg_derive" }
+zone_cfg_derive = { version = "0.3.0", path = "../zone_cfg_derive" }
 tokio = { version = "1.23", features = [ "process" ], optional = true }
 
 [features]

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -17,7 +17,7 @@ use std::string::ToString;
 use thiserror::Error;
 use zone_cfg_derive::Resource;
 
-const PFEXEC: &str = "/bin/pfexec";
+const PFEXEC: &str = "/usr/bin/pfexec";
 const ZONENAME: &str = "/usr/bin/zonename";
 const ZONEADM: &str = "/usr/sbin/zoneadm";
 const ZONECFG: &str = "/usr/sbin/zonecfg";
@@ -597,22 +597,24 @@ impl Config {
     /// This method does not execute `zonecfg` until [`Config::run`]
     /// is invoked.
     pub fn create(name: impl AsRef<str>, overwrite: bool, options: CreationOptions) -> Self {
-        let overwrite_flag = if overwrite {
-            "-F".to_string()
-        } else {
-            "".to_string()
+        let mut cfg = Self::new(name);
+        cfg.push("create");
+        if overwrite {
+            cfg.push("-F");
         };
-        let options = match options {
+        match options {
             CreationOptions::FromDetached(path) => {
-                format!("-a {}", path.into_os_string().to_string_lossy())
+                cfg.push("-a");
+                cfg.push(path.into_os_string().to_string_lossy());
             }
-            CreationOptions::Blank => "-b".to_string(),
-            CreationOptions::Default => "".to_string(),
-            CreationOptions::Template(zone) => format!("-t {}", zone),
+            CreationOptions::Blank => cfg.push("-b"),
+            CreationOptions::Default => (),
+            CreationOptions::Template(zone) => {
+                cfg.push("-t");
+                cfg.push(zone);
+            }
         };
 
-        let mut cfg = Self::new(name);
-        cfg.push(format!("create {} {}", overwrite_flag, options));
         cfg
     }
 
@@ -621,7 +623,9 @@ impl Config {
     /// This method does not execute `zonecfg` until [`Config::run`]
     /// is invoked.
     pub fn export(&mut self, p: impl AsRef<Path>) -> &mut Self {
-        self.push(format!("export -f {}", p.as_ref().to_string_lossy()));
+        self.push("export");
+        self.push("-f");
+        self.push(p.as_ref().to_string_lossy());
         self
     }
 
@@ -630,7 +634,10 @@ impl Config {
     /// This method does not execute `zonecfg` until [`Config::run`]
     /// is invoked.
     pub fn delete(&mut self, force: bool) -> &mut Self {
-        self.push(format!("delete {}", if force { "-F" } else { "" }));
+        self.push("delete");
+        if force {
+            self.push("-F");
+        }
         self
     }
 
@@ -1141,18 +1148,27 @@ mod tests {
             cfg.args,
             &[
                 // Initial resource creation.
-                "add fs",
-                "set type=my-type",
-                "set dir=/path/to/dir",
-                "set special=/path/to/special",
-                "set options=[]",
+                "add",
+                "fs",
+                "set",
+                "type=my-type",
+                "set",
+                "dir=/path/to/dir",
+                "set",
+                "special=/path/to/special",
+                "set",
+                "options=[]",
                 // Set mandatory field.
-                "set dir=/path/to/other/dir",
+                "set",
+                "dir=/path/to/other/dir",
                 // Clear and set optional fied.
-                "clear raw",
-                "set raw=/raw",
+                "clear",
+                "raw",
+                "set",
+                "raw=/raw",
                 // Set a list field.
-                "set options=[abc,def]",
+                "set",
+                "options=[abc,def]",
                 "end"
             ]
         );
@@ -1172,10 +1188,14 @@ mod tests {
         assert_eq!(
             cfg.args,
             &[
-                "add attr",
-                "set name=my-attr",
-                "set type=uint",
-                "set value=10",
+                "add",
+                "attr",
+                "set",
+                "name=my-attr",
+                "set",
+                "type=uint",
+                "set",
+                "value=10",
                 "end"
             ]
         );
@@ -1202,9 +1222,12 @@ mod tests {
         assert_eq!(
             cfg.args,
             &[
-                "add security-flags",
-                "set default=ASLR,FORBIDNULLMAP",
-                "set lower=ASLR",
+                "add",
+                "security-flags",
+                "set",
+                "default=ASLR,FORBIDNULLMAP",
+                "set",
+                "lower=ASLR",
                 "end"
             ]
         );
@@ -1231,13 +1254,20 @@ mod tests {
         assert_eq!(
             cfg.args,
             &[
-                "set zonename=my-new-zone",
-                "set autoboot=false",
-                "clear limitpriv",
-                "set fs-allowed=pcfs,ufs",
-                "set pool=my-pool",
-                "clear pool",
-                "set ip-type=exclusive",
+                "set",
+                "zonename=my-new-zone",
+                "set",
+                "autoboot=false",
+                "clear",
+                "limitpriv",
+                "set",
+                "fs-allowed=pcfs,ufs",
+                "set",
+                "pool=my-pool",
+                "clear",
+                "pool",
+                "set",
+                "ip-type=exclusive",
             ]
         );
     }

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -17,7 +17,7 @@ use std::string::ToString;
 use thiserror::Error;
 use zone_cfg_derive::Resource;
 
-const PFEXEC: &str = "/bin/pfexec";
+const PFEXEC: &str = "/usr/bin/pfexec";
 const ZONENAME: &str = "/usr/bin/zonename";
 const ZONEADM: &str = "/usr/sbin/zoneadm";
 const ZONECFG: &str = "/usr/sbin/zonecfg";

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -1113,7 +1113,7 @@ mod tests {
     #[cfg(target_os = "illumos")]
     #[test]
     fn test_current_zone() {
-        let zone = current().unwrap();
+        let zone = current_blocking().unwrap();
         assert_eq!("global", zone);
     }
 
@@ -1279,14 +1279,14 @@ mod tests {
             ..Default::default()
         });
 
-        cfg.run().unwrap();
-        cfg.delete(true).run().unwrap();
+        cfg.run_blocking().unwrap();
+        cfg.delete(true).run_blocking().unwrap();
     }
 
     #[cfg(target_os = "illumos")]
     #[test]
     fn test_list_global() {
-        let zones = Adm::list().unwrap();
+        let zones = Adm::list_blocking().unwrap();
 
         let global = zones.iter().find(|zone| zone.global()).unwrap();
 
@@ -1304,10 +1304,10 @@ mod tests {
         // Create a zone.
         let mut cfg = Config::create(name, true, CreationOptions::Default);
         cfg.get_global().set_path(path).set_autoboot(true);
-        cfg.run().unwrap();
+        cfg.run_blocking().unwrap();
 
         // Observe that the zone exists.
-        let zone = Adm::list()
+        let zone = Adm::list_blocking()
             .unwrap()
             .into_iter()
             .find(|z| z.name() == name)
@@ -1315,10 +1315,10 @@ mod tests {
         assert_eq!(zone.path(), path);
 
         // Destroy the zone
-        cfg.delete(true).run().unwrap();
+        cfg.delete(true).run_blocking().unwrap();
 
         // Observe the zone does not exist
-        assert!(Adm::list()
+        assert!(Adm::list_blocking()
             .unwrap()
             .into_iter()
             .find(|z| z.name() == name)

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -16,12 +16,6 @@ use std::string::ToString;
 use thiserror::Error;
 use zone_cfg_derive::Resource;
 
-#[cfg(all(feature = "sync", feature = "async"))]
-compile_error!(
-    "The 'sync' and 'async' features are currently mutually exclusive. \
-    This restriction may be lifted in the future."
-);
-
 const PFEXEC: &str = "/bin/pfexec";
 const ZONENAME: &str = "/usr/bin/zonename";
 const ZONEADM: &str = "/usr/sbin/zoneadm";
@@ -639,14 +633,6 @@ impl Config {
         self
     }
 
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'run_blocking', to use the blocking variant, or \n\
-        - Call 'run' using the 'async' feature to call asynchronously.")]
-    pub fn run(&mut self) -> Result<String, ZoneError> {
-        self.run_blocking()
-    }
-
     /// Executes the queued commands for the zone, and clears the
     /// current queued arguments.
     #[cfg(feature = "sync")]
@@ -685,14 +671,6 @@ impl Config {
         self.args.clear();
         Ok(out)
     }
-}
-/// Returns the name of the current zone, if one exists.
-#[cfg(feature = "sync")]
-#[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-    - Call 'current_blocking', to use the blocking variant, or \n\
-    - Call 'current' using the 'async' feature to call asynchronously.")]
-pub fn current() -> Result<String, ZoneError> {
-    current_blocking()
 }
 
 /// Returns the name of the current zone, if one exists.
@@ -853,14 +831,6 @@ impl Adm {
         }
     }
 
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'boot_blocking', to use the blocking variant, or \n\
-        - Call 'boot' using the 'async' feature to call asynchronously.")]
-    pub fn boot(&mut self) -> Result<String, ZoneError> {
-        self.boot_blocking()
-    }
-
     /// Boots (or activates) the zone.
     #[cfg(feature = "sync")]
     pub fn boot_blocking(&mut self) -> Result<String, ZoneError> {
@@ -870,14 +840,6 @@ impl Adm {
     #[cfg(feature = "async")]
     pub async fn boot(&mut self) -> Result<String, ZoneError> {
         self.run(&["boot"]).await
-    }
-
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'clone_blocking', to use the blocking variant, or \n\
-        - Call 'clone' using the 'async' feature to call asynchronously.")]
-    pub fn clone(&mut self, source: impl AsRef<OsStr>) -> Result<String, ZoneError> {
-        self.clone_blocking(source)
     }
 
     /// Installs a zone by copying an existing installed zone.
@@ -891,14 +853,6 @@ impl Adm {
         self.run(&[OsStr::new("clone"), source.as_ref()]).await
     }
 
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'halt_blocking', to use the blocking variant, or \n\
-        - Call 'halt' using the 'async' feature to call asynchronously.")]
-    pub fn halt(&mut self) -> Result<String, ZoneError> {
-        self.halt_blocking()
-    }
-
     /// Halts the specified zone.
     #[cfg(feature = "sync")]
     pub fn halt_blocking(&mut self) -> Result<String, ZoneError> {
@@ -908,14 +862,6 @@ impl Adm {
     #[cfg(feature = "async")]
     pub async fn halt(&mut self) -> Result<String, ZoneError> {
         self.run(&["halt"]).await
-    }
-
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'mount_blocking', to use the blocking variant, or \n\
-        - Call 'mount' using the 'async' feature to call asynchronously.")]
-    pub fn mount(&mut self) -> Result<String, ZoneError> {
-        self.mount_blocking()
     }
 
     // TODO: Not documented in manpage, but apparently this exists.
@@ -929,14 +875,6 @@ impl Adm {
         self.run(&["mount"]).await
     }
 
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'unmount_blocking', to use the blocking variant, or \n\
-        - Call 'unmount' using the 'async' feature to call asynchronously.")]
-    pub fn unmount(&mut self) -> Result<String, ZoneError> {
-        self.unmount_blocking()
-    }
-
     // TODO: Not documented in manpage, but apparently this exists.
     #[cfg(feature = "sync")]
     pub fn unmount_blocking(&mut self) -> Result<String, ZoneError> {
@@ -946,14 +884,6 @@ impl Adm {
     #[cfg(feature = "async")]
     pub async fn unmount(&mut self) -> Result<String, ZoneError> {
         self.run(&["unmount"]).await
-    }
-
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'install_blocking', to use the blocking variant, or \n\
-        - Call 'install' using the 'async' feature to call asynchronously.")]
-    pub fn install(&mut self, brand_specific_options: &[&OsStr]) -> Result<String, ZoneError> {
-        self.install_blocking(brand_specific_options)
     }
 
     /// Install the specified zone on the system.
@@ -975,14 +905,6 @@ impl Adm {
         self.run([command, brand_specific_options].concat()).await
     }
 
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'uninstall_blocking', to use the blocking variant, or \n\
-        - Call 'uninstall' using the 'async' feature to call asynchronously.")]
-    pub fn uninstall(&mut self, force: bool) -> Result<String, ZoneError> {
-        self.uninstall_blocking(force)
-    }
-
     /// Uninstalls the zone from the system.
     #[cfg(feature = "sync")]
     pub fn uninstall_blocking(&mut self, force: bool) -> Result<String, ZoneError> {
@@ -1000,14 +922,6 @@ impl Adm {
             args.push("-F");
         }
         self.run(&args).await
-    }
-
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'list_blocking', to use the blocking variant, or \n\
-        - Call 'list' using the 'async' feature to call asynchronously.")]
-    pub fn list() -> Result<Vec<Zone>, ZoneError> {
-        Self::list_blocking()
     }
 
     /// List all zones.
@@ -1090,14 +1004,6 @@ impl Zlogin {
         Zlogin {
             name: name.as_ref().into(),
         }
-    }
-
-    #[cfg(feature = "sync")]
-    #[deprecated(note = "'zone' now provides asynchronous support. Please either: \n\
-        - Call 'exec_blocking', to use the blocking variant, or \n\
-        - Call 'exec' using the 'async' feature to call asynchronously.")]
-    pub fn exec(&self, cmd: impl AsRef<OsStr>) -> Result<String, ZoneError> {
-        self.exec_blocking(cmd)
     }
 
     /// Executes a command in the zone and returns the result.

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -532,7 +532,7 @@ pub struct Admin {
 /// });
 ///
 /// // Issues the previously enqueued operations to zonecfg.
-/// cfg.run().unwrap();
+/// cfg.run_blocking().unwrap();
 /// ```
 ///
 /// ## Selection and modification of an existing zone.
@@ -550,7 +550,7 @@ pub struct Admin {
 /// cfg.remove_all_capped_memory();
 ///
 /// // Issues the previously enqueued operations to zonecfg.
-/// cfg.run().unwrap();
+/// cfg.run_blocking().unwrap();
 /// ```
 pub struct Config {
     /// Name of the zone.

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -640,7 +640,10 @@ impl Config {
     /// Addiitonally, clears the previously queued arguments.
     pub fn as_command(&mut self) -> Command {
         let separator = ";".to_string();
-        let args = Itertools::intersperse(self.args.iter(), &separator);
+        let args = Itertools::intersperse(self.args.iter(), &separator)
+            .flat_map(|arg| {
+                arg.split(' ')
+            });
         let mut cmd = std::process::Command::new(PFEXEC);
 
         cmd.env_clear()

--- a/zone/src/lib.rs
+++ b/zone/src/lib.rs
@@ -640,10 +640,8 @@ impl Config {
     /// Addiitonally, clears the previously queued arguments.
     pub fn as_command(&mut self) -> Command {
         let separator = ";".to_string();
-        let args = Itertools::intersperse(self.args.iter(), &separator)
-            .flat_map(|arg| {
-                arg.split(' ')
-            });
+        let args =
+            Itertools::intersperse(self.args.iter(), &separator).flat_map(|arg| arg.split(' '));
         let mut cmd = std::process::Command::new(PFEXEC);
 
         cmd.env_clear()

--- a/zone/tests/zlogin_test.rs
+++ b/zone/tests/zlogin_test.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use zone::{Adm, Config, CreationOptions, Zlogin};
 
-const PFEXEC: &str = "/usr/bin/pfexec";
+const PFEXEC: &str = "/bin/pfexec";
 
 // This test is marked with ignore because it involves booting a newly created
 // zone which can take over a minute. This test assumes that the sparse brand is

--- a/zone/tests/zlogin_test.rs
+++ b/zone/tests/zlogin_test.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use zone::{Adm, Config, CreationOptions, Zlogin};
 
-const PFEXEC: &str = "/bin/pfexec";
+const PFEXEC: &str = "/usr/bin/pfexec";
 
 // This test is marked with ignore because it involves booting a newly created
 // zone which can take over a minute. This test assumes that the sparse brand is

--- a/zone_cfg_derive/Cargo.toml
+++ b/zone_cfg_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zone_cfg_derive"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Sean Klein <sean@oxide.computer>"]
 edition = "2018"
 repository = "https://github.com/oxidecomputer/zone"

--- a/zone_cfg_derive/src/lib.rs
+++ b/zone_cfg_derive/src/lib.rs
@@ -136,16 +136,14 @@ fn setters(scope_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro2:
                                 PropertyName::Implicit => #name,
                                 PropertyName::Explicit(name) => name,
                             };
-                            self.push("set");
-                            self.push(format!("{}={}", name, property.value));
+                            self.push(format!("set {}={}", name, property.value));
                         }
                         for property_name in value.get_clearables() {
                             let name = match &property_name {
                                 PropertyName::Implicit => #name,
                                 PropertyName::Explicit(name) => name,
                             };
-                            self.push("clear");
-                            self.push(name);
+                            self.push(format!("clear {}", name));
                         }
                         self
                     }
@@ -192,10 +190,9 @@ fn selectors(input_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro
                             let mut scope = #scope_name {
                                 config: self
                             };
-                            scope.push("select");
-                            scope.push(#input_name_kebab);
                             scope.push(
-                                format!("{}={}",
+                                format!("select {} {}={}",
+                                    #input_name_kebab,
                                     #name,
                                     value,
                                 )
@@ -206,12 +203,10 @@ fn selectors(input_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro
                         #[doc = #remover_msg]
                         pub fn #remover(&mut self, value: impl Into<#ty>) {
                             let value: #ty = value.into();
-                            self.push("remove");
-                            self.push("-F");
-                            self.push(#input_name_kebab);
                             self.push(
                                 format!(
-                                    "{}={}",
+                                    "remove -F {} {}={}",
+                                    #input_name_kebab,
                                     #name,
                                     value,
                                 )
@@ -254,8 +249,7 @@ fn constructor(
                         PropertyName::Implicit => #name,
                         PropertyName::Explicit(name) => name,
                     };
-                    scope.push("set");
-                    scope.push(format!("{}={}", name, property.value));
+                    scope.push(format!("set {}={}", name, property.value));
                 }
             }
         })
@@ -316,17 +310,14 @@ fn constructor(
                         config: self
                     };
 
-                    scope.push("add");
-                    scope.push(#input_name_kebab);
+                    scope.push(format!("add {}", #input_name_kebab));
                     #initial_set_values
                     scope
                 }
 
                 #[doc = #scope_removal_msg]
                 pub fn #scope_removal(&mut self) {
-                    self.push("remove");
-                    self.push("-F");
-                    self.push(#input_name_kebab);
+                    self.push(format!("remove -F {}", #input_name_kebab));
                 }
             }
         }

--- a/zone_cfg_derive/src/lib.rs
+++ b/zone_cfg_derive/src/lib.rs
@@ -136,14 +136,16 @@ fn setters(scope_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro2:
                                 PropertyName::Implicit => #name,
                                 PropertyName::Explicit(name) => name,
                             };
-                            self.push(format!("set {}={}", name, property.value));
+                            self.push("set");
+                            self.push(format!("{}={}", name, property.value));
                         }
                         for property_name in value.get_clearables() {
                             let name = match &property_name {
                                 PropertyName::Implicit => #name,
                                 PropertyName::Explicit(name) => name,
                             };
-                            self.push(format!("clear {}", name));
+                            self.push("clear");
+                            self.push(name);
                         }
                         self
                     }
@@ -190,9 +192,10 @@ fn selectors(input_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro
                             let mut scope = #scope_name {
                                 config: self
                             };
+                            scope.push("select");
+                            scope.push(#input_name_kebab);
                             scope.push(
-                                format!("select {} {}={}",
-                                    #input_name_kebab,
+                                format!("{}={}",
                                     #name,
                                     value,
                                 )
@@ -203,10 +206,12 @@ fn selectors(input_name: &Ident, parsed_fields: &Vec<ParsedField>) -> proc_macro
                         #[doc = #remover_msg]
                         pub fn #remover(&mut self, value: impl Into<#ty>) {
                             let value: #ty = value.into();
+                            self.push("remove");
+                            self.push("-F");
+                            self.push(#input_name_kebab);
                             self.push(
                                 format!(
-                                    "remove -F {} {}={}",
-                                    #input_name_kebab,
+                                    "{}={}",
                                     #name,
                                     value,
                                 )
@@ -249,7 +254,8 @@ fn constructor(
                         PropertyName::Implicit => #name,
                         PropertyName::Explicit(name) => name,
                     };
-                    scope.push(format!("set {}={}", name, property.value));
+                    scope.push("set");
+                    scope.push(format!("{}={}", name, property.value));
                 }
             }
         })
@@ -310,14 +316,17 @@ fn constructor(
                         config: self
                     };
 
-                    scope.push(format!("add {}", #input_name_kebab));
+                    scope.push("add");
+                    scope.push(#input_name_kebab);
                     #initial_set_values
                     scope
                 }
 
                 #[doc = #scope_removal_msg]
                 pub fn #scope_removal(&mut self) {
-                    self.push(format!("remove -F {}", #input_name_kebab));
+                    self.push("remove");
+                    self.push("-F");
+                    self.push(#input_name_kebab);
                 }
             }
         }


### PR DESCRIPTION
This gives callers more control over "when and how commands are executed", which can be useful in test environments. 

For example, see: https://github.com/oxidecomputer/omicron/pull/3442

Additionally, removes deprecated methods.